### PR TITLE
feat(ci): update circle to deploy on release/v.*

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,15 @@
 version: 2.1
 
-defaults: &defaults
-  working_directory: ~/repo
-  docker:
-    - image: circleci/node:latest
+
+executors:
+  node-latest:
+    working_directory: ~/repo
+    docker:
+      - image: circleci/node:latest
 
 jobs:
   init:
-    <<: *defaults
+    executor: node-latest
     steps:
       - checkout
       - run:
@@ -34,7 +36,7 @@ jobs:
             - ~/.build_tools
 
   test:
-    <<: *defaults
+    executor: node-latest
     steps:
       - checkout
       - restore_cache:
@@ -47,7 +49,7 @@ jobs:
           command: npm test
 
   publish-dev:
-    <<: *defaults
+    executor: node-latest
     steps:
       - checkout
       - restore_cache:
@@ -63,7 +65,7 @@ jobs:
           command: npm publish --tag develop
 
   publish-latest:
-    <<: *defaults
+    executor: node-latest
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,17 @@ jobs:
           if [[ "$CIRCLE_BRANCH" =~ release/v.* ]]; then
             ~/.build_tools/node/node_modules/kl-ci-tools/dist/bin.js deps | xargs -I[] npm install []@latest
           fi
+      - run:
+          name: npm build
+          command: npm run build
       - save_cache:
           key: git-sha-{{ .Revision }}{{ .Branch }}
           paths:
+            - dist
             - package.json
             - node_modules
             - ~/.build_tools
+
   test:
     <<: *defaults
     steps:
@@ -33,22 +38,11 @@ jobs:
       - restore_cache:
           key: git-sha-{{ .Revision }}{{ .Branch }}
       - run:
-          name: npm build
-          command: npm run build
-      - run:
           name: lint
           command: npm run lint
       - run:
           name: test
           command: npm test
-      - save_cache:
-          key: git-sha-{{ .Revision }}{{ .Branch }}
-          paths:
-            - package.json
-            - dist
-            - node_modules
-            - ~/.build_tools
-
 
   publish-dev:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: npm install
-          command: npm i
-      - run:
           name: install ci tools
           command: 'mkdir -p ~/.build_tools/node && npm install --prefix ~/.build_tools/node kl-ci-tools'
       - run:
@@ -24,6 +21,9 @@ jobs:
             if [[ "$CIRCLE_BRANCH" =~ release/v.* ]]; then
               ~/.build_tools/node/node_modules/kl-ci-tools/dist/bin.js deps | xargs -I[] npm install []@latest
             fi
+      - run:
+          name: npm install
+          command: npm i
       - run:
           name: npm build
           command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
       - run:
           name: update dependencies if releasing
           command: |
-          if [[ "$CIRCLE_BRANCH" =~ release/v.* ]]; then
-            ~/.build_tools/node/node_modules/kl-ci-tools/dist/bin.js deps | xargs -I[] npm install []@latest
-          fi
+            if [[ "$CIRCLE_BRANCH" =~ release/v.* ]]; then
+              ~/.build_tools/node/node_modules/kl-ci-tools/dist/bin.js deps | xargs -I[] npm install []@latest
+            fi
       - run:
           name: npm build
           command: npm run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,70 +1,129 @@
-version: 2
+version: 2.1
+
+defaults: &defaults
+  working_directory: ~/repo
+  docker:
+    - image: circleci/node:latest
 
 jobs:
-  build:
-    docker:
-      - image: circleci/node:latest
+  init:
+    <<: *defaults
     steps:
       - checkout
       - run:
-          name: Update npm
-          command: 'sudo npm install -g npm@latest'
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          name: npm install
+          command: npm i
       - run:
-          name: NPM Install
-          command: npm install
-      - run:
-          name: NPM Build
-          command: npm run build
+          name: install ci tools
+          command: 'mkdir -p ~/.build_tools/node && npm install --prefix ~/.build_tools/node kl-ci-tools'
+      - run: |
+          if [[ "$CIRCLE_BRANCH" =~ release/v.* ]]; then
+            ~/.build_tools/node/node_modules/kl-ci-tools/dist/bin.js deps | xargs -I[] npm install []@latest
+          fi
       - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: git-sha-{{ .Revision }}{{ .Branch }}
           paths:
+            - package.json
             - node_modules
-            - dist
+            - ~/.build_tools
   test:
-    docker:
-      - image: circleci/node:latest
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: git-sha-{{ .Revision }}{{ .Branch }}
       - run:
-          name: Lint
+          name: npm build
+          command: npm run build
+      - run:
+          name: lint
           command: npm run lint
       - run:
-          name: Test
+          name: test
           command: npm test
+      - save_cache:
+          key: git-sha-{{ .Revision }}{{ .Branch }}
+          paths:
+            - package.json
+            - dist
+            - node_modules
+            - ~/.build_tools
+
+
   publish-dev:
-    docker:
-      - image: circleci/node:latest
+    <<: *defaults
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: git-sha-{{ .Revision }}{{ .Branch }}
       - run:
-          name: Set Develop Version
-          command: git rev-parse develop | cut -c1-10 | xargs -I[] ./node_modules/package-tagger/index.js dev.[]
+          name: set develop version
+          command: git rev-parse develop | cut -c1-10 | xargs -I[] ~/.build_tools/node/node_modules/kl-ci-tools/dist/bin.js tag dev.[]
       - run:
-          name: Authenticate with registry
+          name: authenticate with registry
           command: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > .npmrc
       - run:
-          name: Publish package
+          name: publish package
           command: npm publish --tag develop
 
+  publish-latest:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          key: git-sha-{{ .Revision }}{{ .Branch }}
+      - run:
+          name: setup git config
+          command: git config user.email "dev@mazzaroth.io" && git config user.name "CricleCI" && git config --global core.editor "\usr\local\bin\subl -n -w"
+      - run:
+          name: update version
+          command: echo $CIRCLE_BRANCH | sed 's:release/::' | xargs npm version --no-git-tag-version
+      - run:
+          name: verify package.json
+          command: ~/.build_tools/node/node_modules/kl-ci-tools/dist/bin.js validate
+      - run:
+          name: commit updates
+          command: git add -A && git commit -m "Dependency/Version update for $CIRCLE_BRANCH"
+      - run:
+          name: pull latest from master
+          command: git pull --no-edit -Xours --rebase origin master
+      - run:
+          name: update master
+          command: git checkout master && git rebase -Xtheirs $CIRCLE_BRANCH && git push origin master
+      - run:
+          name: authenticate with registry
+          command: echo "//registry.npmjs.org/:_authToken=$npm_TOKEN" > .npmrc
+      - run:
+          name: publish package
+          command: npm publish --tag latest
+      - run:
+          name: checkout and develop
+          command: git checkout develop
+      - run:
+          name: update develop version
+          command: echo $CIRCLE_BRANCH | sed 's:release/::' | xargs npm --no-git-tag-version version
+      - run:
+          name: commit updates
+          command: git add -A && git commit -m "Version update for $CIRCLE_BRANCH" && git push origin develop
+
 workflows:
-  version: 2
+  version: 2.1
   build_and_test:
     jobs:
-      - build
+      - init
       - test:
           requires:
-            - build
+            - init
       - publish-dev:
           requires:
-            - build
             - test
           filters:
             branches:
               only: develop
+      - publish-latest:
+          requires:
+            - test
+          filters:
+            branches:
+              only: /release\/v([0-9]+)\.([0-9]+)\.([0-9]+)$/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ jobs:
       - run:
           name: install ci tools
           command: 'mkdir -p ~/.build_tools/node && npm install --prefix ~/.build_tools/node kl-ci-tools'
-      - run: |
+      - run:
+          name: update dependencies if releasing
+          command: |
           if [[ "$CIRCLE_BRANCH" =~ release/v.* ]]; then
             ~/.build_tools/node/node_modules/kl-ci-tools/dist/bin.js deps | xargs -I[] npm install []@latest
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 package-lock.json
+.npmrc


### PR DESCRIPTION
Updating our ci for xdr-js-serialize.

This should allow us to cut releases by branching off of develop in the format: release/v0.2.0